### PR TITLE
CE-425 ParserUtil::sanitizeUrl() in Location::setUrl() adds unnecessa…

### DIFF
--- a/Entity/Slideshow.php
+++ b/Entity/Slideshow.php
@@ -12,6 +12,7 @@ namespace CampaignChain\Operation\SlideShareBundle\Entity;
 
 use CampaignChain\CoreBundle\Entity\Meta;
 use Doctrine\ORM\Mapping as ORM;
+use CampaignChain\CoreBundle\Util\ParserUtil;
 
 /**
  * @ORM\Entity
@@ -88,7 +89,7 @@ class Slideshow extends Meta
      */
     public function setUrl($url)
     {
-        $this->url = $url;
+        $this->url = ParserUtil::sanitizeUrl($url);
 
         return $this;
     }


### PR DESCRIPTION
…ry trailing slash that causes e.g. GoToWebinar links to not work
